### PR TITLE
Add federal separation allowance calculator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.venv/
+
+# pytest cache
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Der Fokus liegt auf Transparenz und Nachvollziehbarkeit der Rechenschritte.
   Eingabe tatsächlicher Kosten
 * Optionales Einlesen der Eingabedaten aus einer JSON-Datei
 * Kommandozeilenwerkzeug `trennungsgeld`
+* Grafische Oberfläche für eine komfortable Datenerfassung
 
 ## Annahmen
 
@@ -65,6 +66,19 @@ python -m trennungsgeld.cli --full-days 5 --arrival-days 2 --partial-days 3 \
 ```
 
 Die Ausgabe enthält eine übersichtliche Aufschlüsselung aller Teilbeträge.
+
+### Grafische Oberfläche
+
+Eine Desktop-Oberfläche auf Basis von Tkinter kann mit folgendem Befehl gestartet
+werden:
+
+```bash
+python -m trennungsgeld.gui
+```
+
+Nach dem Start lassen sich alle Eingabeparameter bequem erfassen. Über den
+Button **Berechnen** wird die aktuelle Prognose inklusive Detailauflistung
+angezeigt.
 
 ### Eingabe über JSON
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,103 @@
-# Trennungsgeld
+# Trennungsgeldrechner
+
+Dieses Projekt stellt einen leichtgewichtigen Rechner zur Verfügung, mit dem sich
+der voraussichtliche Trennungsgeldanspruch auf Bundesebene nach
+Bundesreisekostengesetz (BRKG) inklusive Reisekosten überschlägig ermitteln lässt.
+Der Fokus liegt auf Transparenz und Nachvollziehbarkeit der Rechenschritte.
+
+## Funktionsumfang
+
+* Berechnung von Verpflegungsmehraufwand und Übernachtungskosten anhand der
+  BRKG-Pauschalen (Stand 2024)
+* Ermittlung erstattungsfähiger Reisekosten inkl. An- und Abreise,
+  genehmigter Heimfahrten sowie täglicher Pendelfahrten
+* Unterstützung von Kilometerpauschalen für Pkw, Motorrad und Fahrrad oder der
+  Eingabe tatsächlicher Kosten
+* Optionales Einlesen der Eingabedaten aus einer JSON-Datei
+* Kommandozeilenwerkzeug `trennungsgeld`
+
+## Annahmen
+
+Das Bundesreisekostengesetz kennt zahlreiche Sonder- und Übergangsregelungen.
+Der Rechner bildet die wichtigsten Standardfälle ab und trifft folgende Annahmen:
+
+* Für die Verpflegungspauschalen gelten 28 EUR für volle 24-Stunden-Tage sowie
+  14 EUR für An- bzw. Abreisetage und weitere Tage mit mehr als acht Stunden
+  Abwesenheit.
+* Übernachtungskosten können entweder als belegte Gesamtsumme angegeben werden
+  oder – falls keine Belege vorliegen – über eine Pauschale von 20 EUR pro Nacht.
+* Reisekosten werden standardmäßig über Kilometerpauschalen berechnet. Sofern
+  tatsächliche Kosten angegeben werden, überschreiben sie die Pauschalen.
+* Heimfahrten werden mit der Entfernung einer einfachen Strecke angesetzt.
+
+Die getroffenen Annahmen orientieren sich an den bundeseinheitlichen Vorgaben.
+Für Spezialfälle (z. B. Trennungsentschädigung nach längeren Abordnungen,
+Mischformen mit Umzugskostenrecht oder landesspezifische Abweichungen) ist eine
+manuelle Prüfung erforderlich.
+
+## Installation
+
+Das Projekt nutzt Python 3.11 oder neuer. Optional lässt sich ein virtuelles
+Umfeld verwenden:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+Tests werden mit `pytest` ausgeführt:
+
+```bash
+pytest
+```
+
+## Nutzung
+
+Nach der Installation steht der Befehl `trennungsgeld` zur Verfügung. Alternativ
+kann das Modul direkt mit Python ausgeführt werden:
+
+```bash
+python -m trennungsgeld.cli --full-days 5 --arrival-days 2 --partial-days 3 \
+  --overnight-receipts 4 --overnight-costs 320 --overnight-flat 2 \
+  --vehicle car --initial-trip-km 500 --home-trips 3 --home-trip-km 400 \
+  --commuting-days 10 --commuting-distance 15 --additional-costs 50
+```
+
+Die Ausgabe enthält eine übersichtliche Aufschlüsselung aller Teilbeträge.
+
+### Eingabe über JSON
+
+Eingaben können in einer JSON-Datei strukturiert werden. Beispiel `daten.json`:
+
+```json
+{
+  "meal_allowance": {
+    "full_days": 5,
+    "arrival_departure_days": 2,
+    "partial_days": 3,
+    "overnight_stays_with_receipts": 4,
+    "overnight_costs_total": 320,
+    "overnight_stays_without_receipts": 2
+  },
+  "travel_costs": {
+    "vehicle": "car",
+    "initial_trip_distance_km": 500,
+    "weekly_home_trips": 3,
+    "home_trip_distance_km": 400,
+    "commuting_days": 10,
+    "commuting_distance_km": 15,
+    "additional_costs": 50
+  }
+}
+```
+
+Aufruf:
+
+```bash
+python -m trennungsgeld.cli --input daten.json
+```
+
+## Lizenz
+
+Veröffentlicht unter der MIT-Lizenz.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "trennungsgeld"
+version = "0.1.0"
+description = "Rechner für Trennungsgeld auf Bundesebene inklusive Reisekosten"
+readme = "README.md"
+authors = [{name = "Bundesrechner", email = "example@example.com"}]
+requires-python = ">=3.11"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.scripts]
+trennungsgeld = "trennungsgeld.cli:main"
+
+[tool.pytest.ini_options]
+addopts = "-q"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 
 [project.scripts]
 trennungsgeld = "trennungsgeld.cli:main"
+trennungsgeld-gui = "trennungsgeld.gui:launch_gui"
 
 [tool.pytest.ini_options]
 addopts = "-q"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,0 +1,80 @@
+from trennungsgeld.calculator import (
+    AllowanceInput,
+    AllowanceRates,
+    CalculationResult,
+    TrennungsgeldCalculator,
+    TravelCostInput,
+    TravelRates,
+)
+
+
+def test_meal_allowance_basic():
+    calculator = TrennungsgeldCalculator()
+    data = AllowanceInput(
+        full_days=5,
+        arrival_departure_days=2,
+        partial_days=3,
+        overnight_stays_with_receipts=4,
+        overnight_costs_total=320.0,
+        overnight_stays_without_receipts=2,
+    )
+
+    components = calculator.calculate_meal_allowance(data)
+
+    expected_total = (
+        5 * calculator.allowance_rates.full_day
+        + 2 * calculator.allowance_rates.arrival_departure
+        + 3 * calculator.allowance_rates.partial_day
+        + 320.0
+        + 2 * calculator.allowance_rates.overnight_flat
+    )
+
+    assert components["total_meal_allowance"] == expected_total
+
+
+def test_travel_costs_with_mixed_inputs():
+    rates = TravelRates(car_per_km=0.2)
+    calculator = TrennungsgeldCalculator(travel_rates=rates)
+    data = TravelCostInput(
+        initial_trip_distance_km=500,
+        return_trip_actual_cost=120.0,
+        weekly_home_trips=4,
+        home_trip_distance_km=400,
+        commuting_days=10,
+        commuting_distance_km=15,
+        additional_costs=50.0,
+    )
+
+    components = calculator.calculate_travel_costs(data)
+
+    expected_initial = 500 * rates.car_per_km
+    expected_home = 4 * 400 * rates.car_per_km
+    expected_commuting = 10 * 15 * rates.car_per_km
+    expected_total = (
+        expected_initial
+        + 120.0
+        + expected_home
+        + expected_commuting
+        + 50.0
+    )
+
+    assert components["total_travel_costs"] == expected_total
+
+
+def test_calculate_combined():
+    calculator = TrennungsgeldCalculator(
+        allowance_rates=AllowanceRates(full_day=28, arrival_departure=14, partial_day=14),
+        travel_rates=TravelRates(car_per_km=0.2),
+    )
+
+    allowance_input = AllowanceInput(full_days=2, arrival_departure_days=1, partial_days=0)
+    travel_input = TravelCostInput(initial_trip_distance_km=100)
+
+    result = calculator.calculate(allowance_input, travel_input)
+
+    assert isinstance(result, CalculationResult)
+    assert result.meal_allowance == 2 * 28 + 1 * 14
+    assert result.travel_costs == 100 * 0.2
+    assert result.total_allowance == result.meal_allowance + result.travel_costs
+    assert "meal_full_days" in result.breakdown
+    assert "travel_initial_trip" in result.breakdown

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,33 @@
+"""Tests für Hilfsfunktionen der grafischen Oberfläche."""
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+def test_gui_module_does_not_import_tkinter_by_default() -> None:
+    sys.modules.pop("trennungsgeld.gui", None)
+    sys.modules.pop("tkinter", None)
+    module = importlib.import_module("trennungsgeld.gui")
+    assert "tkinter" not in sys.modules
+    assert hasattr(module, "launch_gui")
+
+
+def test_parse_helpers() -> None:
+    from trennungsgeld.gui import parse_float, parse_int, parse_optional_float
+
+    assert parse_int("5", "Test") == 5
+    assert parse_int("   ", "Test") == 0
+    assert parse_float("3.5", "Test") == pytest.approx(3.5)
+    assert parse_float("", "Test") == pytest.approx(0.0)
+    assert parse_optional_float("", "Test") is None
+    assert parse_optional_float("42", "Test") == pytest.approx(42)
+
+    with pytest.raises(ValueError):
+        parse_int("abc", "Feld")
+    with pytest.raises(ValueError):
+        parse_float("abc", "Feld")
+    with pytest.raises(ValueError):
+        parse_optional_float("abc", "Feld")

--- a/trennungsgeld/__init__.py
+++ b/trennungsgeld/__init__.py
@@ -1,0 +1,21 @@
+"""Trennungsgeldrechner gemäß Bundesreisekostengesetz (BRKG)."""
+
+from .calculator import (
+    AllowanceInput,
+    AllowanceRates,
+    CalculationResult,
+    TrennungsgeldCalculator,
+    TravelCostInput,
+    TravelRates,
+    format_breakdown,
+)
+
+__all__ = [
+    "AllowanceInput",
+    "AllowanceRates",
+    "CalculationResult",
+    "TrennungsgeldCalculator",
+    "TravelCostInput",
+    "TravelRates",
+    "format_breakdown",
+]

--- a/trennungsgeld/__init__.py
+++ b/trennungsgeld/__init__.py
@@ -9,6 +9,7 @@ from .calculator import (
     TravelRates,
     format_breakdown,
 )
+from .gui import launch_gui
 
 __all__ = [
     "AllowanceInput",
@@ -18,4 +19,5 @@ __all__ = [
     "TravelCostInput",
     "TravelRates",
     "format_breakdown",
+    "launch_gui",
 ]

--- a/trennungsgeld/calculator.py
+++ b/trennungsgeld/calculator.py
@@ -1,0 +1,240 @@
+"""Utilities to estimate federal German separation allowance (Trennungsgeld).
+
+The module intentionally focuses on transparency rather than covering every
+special case covered by the Bundesreisekostengesetz (BRKG).  The implemented
+rules follow the BRKG rates as of 2024 for meal allowances and kilometre-based
+travel reimbursements.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class AllowanceRates:
+    """Allowance rates in Euro according to the BRKG.
+
+    The defaults reflect the 2024 federal rates:
+
+    * 28 EUR for full 24-hour absences
+    * 14 EUR for arrival or departure days
+    * 14 EUR for partial days with more than 8 hours of absence
+    * 20 EUR flat overnight allowance when no receipts are provided
+    """
+
+    full_day: float = 28.0
+    arrival_departure: float = 14.0
+    partial_day: float = 14.0
+    overnight_flat: float = 20.0
+
+
+@dataclass(frozen=True)
+class TravelRates:
+    """Mileage reimbursement rates in Euro per kilometre.
+
+    The standard BRKG kilometre allowance for cars is 0.20 EUR per kilometre.
+    Lower rates are used for motorcycles and bicycles.
+    """
+
+    car_per_km: float = 0.20
+    motorcycle_per_km: float = 0.13
+    bicycle_per_km: float = 0.05
+
+
+@dataclass(frozen=True)
+class AllowanceInput:
+    """Inputs for the meal allowance component of the calculation."""
+
+    full_days: int
+    arrival_departure_days: int
+    partial_days: int
+    overnight_stays_with_receipts: int = 0
+    overnight_costs_total: float = 0.0
+    overnight_stays_without_receipts: int = 0
+
+
+@dataclass(frozen=True)
+class TravelCostInput:
+    """Inputs required to estimate reimbursable travel costs."""
+
+    initial_trip_distance_km: float = 0.0
+    initial_trip_actual_cost: Optional[float] = None
+    return_trip_distance_km: float = 0.0
+    return_trip_actual_cost: Optional[float] = None
+    weekly_home_trips: int = 0
+    home_trip_distance_km: float = 0.0
+    home_trip_actual_cost: Optional[float] = None
+    commuting_days: int = 0
+    commuting_distance_km: float = 0.0
+    commuting_actual_cost_per_day: Optional[float] = None
+    additional_costs: float = 0.0
+    vehicle: str = "car"
+
+
+@dataclass
+class CalculationResult:
+    """Structured result of the calculator."""
+
+    total_allowance: float
+    meal_allowance: float
+    travel_costs: float
+    breakdown: Dict[str, float] = field(default_factory=dict)
+
+
+class TrennungsgeldCalculator:
+    """Central service to calculate the estimated separation allowance."""
+
+    def __init__(
+        self,
+        allowance_rates: AllowanceRates | None = None,
+        travel_rates: TravelRates | None = None,
+    ) -> None:
+        self.allowance_rates = allowance_rates or AllowanceRates()
+        self.travel_rates = travel_rates or TravelRates()
+
+    def calculate_meal_allowance(self, data: AllowanceInput) -> Dict[str, float]:
+        """Calculate the meal (Verpflegung) and overnight allowances."""
+
+        if min(data.full_days, data.arrival_departure_days, data.partial_days) < 0:
+            raise ValueError("Day counts must be non-negative")
+
+        components: Dict[str, float] = {}
+
+        full_day_amount = data.full_days * self.allowance_rates.full_day
+        components["full_days"] = full_day_amount
+
+        arrival_amount = (
+            data.arrival_departure_days * self.allowance_rates.arrival_departure
+        )
+        components["arrival_departure_days"] = arrival_amount
+
+        partial_amount = data.partial_days * self.allowance_rates.partial_day
+        components["partial_days"] = partial_amount
+
+        if data.overnight_stays_with_receipts < 0 or data.overnight_costs_total < 0:
+            raise ValueError("Overnight stays and costs must be non-negative")
+
+        components["overnight_with_receipts"] = data.overnight_costs_total
+
+        if data.overnight_stays_without_receipts < 0:
+            raise ValueError("Number of overnight stays without receipts must be non-negative")
+
+        overnight_flat_amount = (
+            data.overnight_stays_without_receipts
+            * self.allowance_rates.overnight_flat
+        )
+        components["overnight_without_receipts"] = overnight_flat_amount
+
+        components["total_meal_allowance"] = sum(components.values())
+        return components
+
+    def _rate_for_vehicle(self, vehicle: str) -> float:
+        rate_lookup = {
+            "car": self.travel_rates.car_per_km,
+            "motorcycle": self.travel_rates.motorcycle_per_km,
+            "bike": self.travel_rates.bicycle_per_km,
+            "bicycle": self.travel_rates.bicycle_per_km,
+        }
+        try:
+            return rate_lookup[vehicle]
+        except KeyError as exc:  # pragma: no cover - defensive coding
+            raise ValueError(
+                f"Unsupported vehicle '{vehicle}'. Choose from {', '.join(rate_lookup)}."
+            ) from exc
+
+    def calculate_travel_costs(self, data: TravelCostInput) -> Dict[str, float]:
+        """Calculate reimbursable travel costs."""
+
+        components: Dict[str, float] = {}
+        rate = self._rate_for_vehicle(data.vehicle)
+
+        def km_or_cost(distance_km: float, actual_cost: Optional[float]) -> float:
+            if actual_cost is not None:
+                if actual_cost < 0:
+                    raise ValueError("Actual costs must not be negative")
+                return actual_cost
+            if distance_km < 0:
+                raise ValueError("Distances must not be negative")
+            return distance_km * rate
+
+        components["initial_trip"] = km_or_cost(
+            data.initial_trip_distance_km, data.initial_trip_actual_cost
+        )
+        components["return_trip"] = km_or_cost(
+            data.return_trip_distance_km, data.return_trip_actual_cost
+        )
+
+        home_trip_amount = km_or_cost(
+            data.home_trip_distance_km, data.home_trip_actual_cost
+        ) * data.weekly_home_trips
+        components["home_trips"] = home_trip_amount
+
+        commuting_amount = 0.0
+        if data.commuting_actual_cost_per_day is not None:
+            if data.commuting_actual_cost_per_day < 0:
+                raise ValueError("Commuting cost per day must be non-negative")
+            commuting_amount = data.commuting_actual_cost_per_day * data.commuting_days
+        else:
+            if data.commuting_distance_km < 0 or data.commuting_days < 0:
+                raise ValueError("Commuting distance and days must be non-negative")
+            commuting_amount = (
+                data.commuting_distance_km * data.commuting_days * rate
+            )
+        components["commuting"] = commuting_amount
+
+        if data.additional_costs < 0:
+            raise ValueError("Additional costs must be non-negative")
+        components["additional_costs"] = data.additional_costs
+
+        components["total_travel_costs"] = sum(components.values())
+        return components
+
+    def calculate(
+        self,
+        allowance_input: AllowanceInput,
+        travel_input: TravelCostInput,
+    ) -> CalculationResult:
+        meal_components = self.calculate_meal_allowance(allowance_input)
+        travel_components = self.calculate_travel_costs(travel_input)
+
+        meal_total = meal_components.pop("total_meal_allowance")
+        travel_total = travel_components.pop("total_travel_costs")
+
+        total = meal_total + travel_total
+        breakdown: Dict[str, float] = {}
+        breakdown.update({f"meal_{k}": v for k, v in meal_components.items()})
+        breakdown.update({f"travel_{k}": v for k, v in travel_components.items()})
+
+        return CalculationResult(
+            total_allowance=total,
+            meal_allowance=meal_total,
+            travel_costs=travel_total,
+            breakdown=breakdown,
+        )
+
+
+def format_breakdown(result: CalculationResult) -> List[str]:
+    """Generate a human readable breakdown list."""
+
+    lines = [
+        "Berechnungsübersicht:",
+        f"  Gesamtsumme: {result.total_allowance:.2f} EUR",
+        f"  Verpflegung und Übernachtung: {result.meal_allowance:.2f} EUR",
+        f"  Reisekosten: {result.travel_costs:.2f} EUR",
+        "  Detailposten:",
+    ]
+    for key, value in sorted(result.breakdown.items()):
+        lines.append(f"    {key}: {value:.2f} EUR")
+    return lines
+
+
+__all__ = [
+    "AllowanceRates",
+    "TravelRates",
+    "AllowanceInput",
+    "TravelCostInput",
+    "CalculationResult",
+    "TrennungsgeldCalculator",
+    "format_breakdown",
+]

--- a/trennungsgeld/cli.py
+++ b/trennungsgeld/cli.py
@@ -1,0 +1,193 @@
+"""Command line interface for the Trennungsgeld calculator."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from .calculator import (
+    AllowanceInput,
+    TrennungsgeldCalculator,
+    TravelCostInput,
+    format_breakdown,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Berechnet eine Prognose für den Trennungsgeldanspruch auf "
+            "Bundesebene inklusive Reisekosten."
+        )
+    )
+
+    parser.add_argument(
+        "--input",
+        type=Path,
+        help=(
+            "Optionaler Pfad zu einer JSON-Datei mit den Eingabedaten. "
+            "Im JSON können sowohl meal_allowance als auch travel_costs "
+            "Objekte definiert werden."
+        ),
+    )
+
+    meal = parser.add_argument_group("Verpflegungs- und Übernachtungskosten")
+    meal.add_argument("--full-days", type=int, default=0, help="Anzahl voller Abwesenheitstage")
+    meal.add_argument(
+        "--arrival-days",
+        type=int,
+        default=0,
+        help="Anzahl von An- oder Abreisetagen",
+    )
+    meal.add_argument(
+        "--partial-days",
+        type=int,
+        default=0,
+        help="Anzahl weiterer Tage mit mehr als 8 Stunden Abwesenheit",
+    )
+    meal.add_argument(
+        "--overnight-receipts",
+        type=int,
+        default=0,
+        help="Übernachtungen mit Belegen",
+    )
+    meal.add_argument(
+        "--overnight-costs",
+        type=float,
+        default=0.0,
+        help="Summe der belegten Übernachtungskosten",
+    )
+    meal.add_argument(
+        "--overnight-flat",
+        type=int,
+        default=0,
+        help="Übernachtungen ohne Beleg (20 EUR Pauschale)",
+    )
+
+    travel = parser.add_argument_group("Reisekosten")
+    travel.add_argument(
+        "--vehicle",
+        choices=["car", "motorcycle", "bike"],
+        default="car",
+        help="Fortbewegungsmittel für Kilometerpauschalen",
+    )
+    travel.add_argument(
+        "--initial-trip-km",
+        type=float,
+        default=0.0,
+        help="Kilometer bei der Anreise zur neuen Dienststelle",
+    )
+    travel.add_argument(
+        "--initial-trip-cost",
+        type=float,
+        help="Tatsächliche Kosten der Anreise (überschreibt Kilometerangabe)",
+    )
+    travel.add_argument(
+        "--return-trip-km",
+        type=float,
+        default=0.0,
+        help="Kilometer bei der endgültigen Rückreise",
+    )
+    travel.add_argument(
+        "--return-trip-cost",
+        type=float,
+        help="Tatsächliche Kosten der Rückreise",
+    )
+    travel.add_argument(
+        "--home-trips",
+        type=int,
+        default=0,
+        help="Anzahl genehmigter Heimfahrten",
+    )
+    travel.add_argument(
+        "--home-trip-km",
+        type=float,
+        default=0.0,
+        help="Entfernung einer Heimfahrt (einfache Strecke)",
+    )
+    travel.add_argument(
+        "--home-trip-cost",
+        type=float,
+        help="Tatsächliche Kosten einer Heimfahrt",
+    )
+    travel.add_argument(
+        "--commuting-days",
+        type=int,
+        default=0,
+        help="Anzahl täglicher Fahrten zwischen Unterkunft und Dienststelle",
+    )
+    travel.add_argument(
+        "--commuting-distance",
+        type=float,
+        default=0.0,
+        help="Entfernung einer einfachen Pendelstrecke",
+    )
+    travel.add_argument(
+        "--commuting-cost",
+        type=float,
+        help="Tatsächliche Kosten pro Pendeltag",
+    )
+    travel.add_argument(
+        "--additional-costs",
+        type=float,
+        default=0.0,
+        help="Weitere erstattungsfähige Kosten (z.B. Gepäck, Parken)",
+    )
+
+    return parser.parse_args()
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Die JSON-Datei muss ein Objekt enthalten")
+    return data
+
+
+def _build_inputs(args: argparse.Namespace) -> tuple[AllowanceInput, TravelCostInput]:
+    allowance_kwargs = dict(
+        full_days=args.full_days,
+        arrival_departure_days=args.arrival_days,
+        partial_days=args.partial_days,
+        overnight_stays_with_receipts=args.overnight_receipts,
+        overnight_costs_total=args.overnight_costs,
+        overnight_stays_without_receipts=args.overnight_flat,
+    )
+
+    travel_kwargs = dict(
+        vehicle=args.vehicle,
+        initial_trip_distance_km=args.initial_trip_km,
+        initial_trip_actual_cost=args.initial_trip_cost,
+        return_trip_distance_km=args.return_trip_km,
+        return_trip_actual_cost=args.return_trip_cost,
+        weekly_home_trips=args.home_trips,
+        home_trip_distance_km=args.home_trip_km,
+        home_trip_actual_cost=args.home_trip_cost,
+        commuting_days=args.commuting_days,
+        commuting_distance_km=args.commuting_distance,
+        commuting_actual_cost_per_day=args.commuting_cost,
+        additional_costs=args.additional_costs,
+    )
+
+    if args.input:
+        file_data = _load_json(args.input)
+        allowance_kwargs.update(file_data.get("meal_allowance", {}))
+        travel_kwargs.update(file_data.get("travel_costs", {}))
+
+    return AllowanceInput(**allowance_kwargs), TravelCostInput(**travel_kwargs)
+
+
+def main() -> None:
+    args = parse_args()
+    allowance_input, travel_input = _build_inputs(args)
+
+    calculator = TrennungsgeldCalculator()
+    result = calculator.calculate(allowance_input, travel_input)
+
+    for line in format_breakdown(result):
+        print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/trennungsgeld/gui.py
+++ b/trennungsgeld/gui.py
@@ -1,0 +1,299 @@
+"""Graphische Benutzeroberfläche für den Trennungsgeldrechner."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional, Sequence
+
+from .calculator import (
+    AllowanceInput,
+    TrennungsgeldCalculator,
+    TravelCostInput,
+    format_breakdown,
+)
+
+
+NumberParser = Callable[[str, str], int | float | None]
+
+
+def parse_int(value: str, label: str) -> int:
+    """Parse an integer value from a text field."""
+
+    text = value.strip()
+    if not text:
+        return 0
+    try:
+        return int(text)
+    except ValueError as exc:  # pragma: no cover - defensive programming
+        raise ValueError(f"{label}: Bitte eine ganze Zahl eingeben.") from exc
+
+
+def parse_float(value: str, label: str) -> float:
+    """Parse a float value from a text field."""
+
+    text = value.strip()
+    if not text:
+        return 0.0
+    try:
+        return float(text)
+    except ValueError as exc:  # pragma: no cover - defensive programming
+        raise ValueError(f"{label}: Bitte eine Zahl eingeben.") from exc
+
+
+def parse_optional_float(value: str, label: str) -> Optional[float]:
+    """Parse an optional float, allowing empty strings."""
+
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError as exc:  # pragma: no cover - defensive programming
+        raise ValueError(
+            f"{label}: Bitte eine Zahl eingeben oder das Feld leer lassen."
+        ) from exc
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    """Configuration for a single input field."""
+
+    key: str
+    label: str
+    parser: NumberParser
+    default: str = "0"
+
+
+MEAL_FIELDS: Sequence[FieldSpec] = (
+    FieldSpec("full_days", "Volle Abwesenheitstage", parse_int),
+    FieldSpec("arrival_departure_days", "An- oder Abreisetage", parse_int),
+    FieldSpec("partial_days", "Weitere Tage (>8h)", parse_int),
+    FieldSpec(
+        "overnight_stays_with_receipts",
+        "Übernachtungen mit Beleg",
+        parse_int,
+    ),
+    FieldSpec(
+        "overnight_costs_total",
+        "Summe belegter Übernachtungskosten",
+        parse_float,
+        "0.0",
+    ),
+    FieldSpec(
+        "overnight_stays_without_receipts",
+        "Übernachtungen ohne Beleg",
+        parse_int,
+    ),
+)
+
+
+TRAVEL_FIELDS: Sequence[FieldSpec] = (
+    FieldSpec("initial_trip_distance_km", "Anreise (km)", parse_float, "0.0"),
+    FieldSpec(
+        "initial_trip_actual_cost",
+        "Anreise tatsächliche Kosten",
+        parse_optional_float,
+        "",
+    ),
+    FieldSpec("return_trip_distance_km", "Rückreise (km)", parse_float, "0.0"),
+    FieldSpec(
+        "return_trip_actual_cost",
+        "Rückreise tatsächliche Kosten",
+        parse_optional_float,
+        "",
+    ),
+    FieldSpec("weekly_home_trips", "Genehmigte Heimfahrten", parse_int),
+    FieldSpec("home_trip_distance_km", "Heimfahrt (km)", parse_float, "0.0"),
+    FieldSpec(
+        "home_trip_actual_cost",
+        "Heimfahrt tatsächliche Kosten",
+        parse_optional_float,
+        "",
+    ),
+    FieldSpec("commuting_days", "Pendeltage", parse_int),
+    FieldSpec("commuting_distance_km", "Pendelstrecke (km)", parse_float, "0.0"),
+    FieldSpec(
+        "commuting_actual_cost_per_day",
+        "Pendelkosten pro Tag",
+        parse_optional_float,
+        "",
+    ),
+    FieldSpec("additional_costs", "Weitere Kosten", parse_float, "0.0"),
+)
+
+
+class CalculatorGUI:
+    """Encapsulates the Tkinter based graphical user interface."""
+
+    def __init__(
+        self,
+        root,
+        tk_module,
+        ttk_module,
+        messagebox_module,
+        scrolledtext_cls,
+    ) -> None:
+        self.root = root
+        self.tk = tk_module
+        self.ttk = ttk_module
+        self.messagebox = messagebox_module
+        self.scrolledtext_cls = scrolledtext_cls
+
+        self.calculator = TrennungsgeldCalculator()
+        self.vars: Dict[str, "tk_module.StringVar"] = {}
+        self.vehicle_var = tk_module.StringVar(value="car")
+        self.total_var = tk_module.StringVar(value="0.00 EUR")
+        self.meal_var = tk_module.StringVar(value="0.00 EUR")
+        self.travel_var = tk_module.StringVar(value="0.00 EUR")
+
+        self._build_layout()
+
+    def _build_layout(self) -> None:
+        root = self.root
+        root.title("Trennungsgeldrechner")
+        root.minsize(720, 540)
+
+        main = self.ttk.Frame(root, padding=12)
+        main.grid(row=0, column=0, sticky="nsew")
+        root.columnconfigure(0, weight=1)
+        root.rowconfigure(0, weight=1)
+
+        main.columnconfigure(0, weight=1)
+        main.columnconfigure(1, weight=1)
+        main.rowconfigure(2, weight=1)
+
+        meal_frame = self.ttk.LabelFrame(main, text="Verpflegung & Übernachtung")
+        meal_frame.grid(row=0, column=0, sticky="nsew", padx=(0, 8), pady=(0, 8))
+        self._build_fields(meal_frame, MEAL_FIELDS)
+
+        travel_frame = self.ttk.LabelFrame(main, text="Reisekosten")
+        travel_frame.grid(row=0, column=1, sticky="nsew", padx=(8, 0), pady=(0, 8))
+        self._build_fields(travel_frame, TRAVEL_FIELDS)
+        self._build_vehicle_selector(travel_frame)
+
+        button_frame = self.ttk.Frame(main)
+        button_frame.grid(row=1, column=0, columnspan=2, sticky="ew", pady=(0, 8))
+        button_frame.columnconfigure(0, weight=1)
+
+        calculate_btn = self.ttk.Button(
+            button_frame,
+            text="Berechnen",
+            command=self._on_calculate,
+        )
+        calculate_btn.grid(row=0, column=0, sticky="e")
+
+        totals = self.ttk.Frame(main)
+        totals.grid(row=2, column=0, columnspan=2, sticky="ew", pady=(0, 8))
+        totals.columnconfigure(1, weight=1)
+        totals.columnconfigure(3, weight=1)
+
+        self.ttk.Label(totals, text="Gesamt:").grid(row=0, column=0, sticky="w")
+        self.ttk.Label(totals, textvariable=self.total_var).grid(
+            row=0, column=1, sticky="w"
+        )
+        self.ttk.Label(totals, text="Verpflegung:").grid(row=0, column=2, sticky="w")
+        self.ttk.Label(totals, textvariable=self.meal_var).grid(
+            row=0, column=3, sticky="w"
+        )
+        self.ttk.Label(totals, text="Reisekosten:").grid(row=0, column=4, sticky="w")
+        self.ttk.Label(totals, textvariable=self.travel_var).grid(
+            row=0, column=5, sticky="w"
+        )
+
+        output_frame = self.ttk.LabelFrame(main, text="Berechnungsübersicht")
+        output_frame.grid(row=3, column=0, columnspan=2, sticky="nsew")
+        main.rowconfigure(3, weight=1)
+        output_frame.rowconfigure(0, weight=1)
+        output_frame.columnconfigure(0, weight=1)
+
+        self.output = self.scrolledtext_cls(output_frame, wrap="word", height=10)
+        self.output.grid(row=0, column=0, sticky="nsew")
+        self._set_output_text(
+            "Bitte Werte eingeben und auf 'Berechnen' klicken, um eine Prognose zu erhalten."
+        )
+
+    def _build_fields(self, parent, specs: Sequence[FieldSpec]) -> None:
+        for row, spec in enumerate(specs):
+            self.ttk.Label(parent, text=spec.label).grid(
+                row=row, column=0, sticky="w", padx=4, pady=2
+            )
+            var = self.tk.StringVar(value=spec.default)
+            entry = self.ttk.Entry(parent, textvariable=var, width=18)
+            entry.grid(row=row, column=1, sticky="ew", padx=4, pady=2)
+            parent.columnconfigure(1, weight=1)
+            self.vars[spec.key] = var
+
+    def _build_vehicle_selector(self, parent) -> None:
+        row = len(TRAVEL_FIELDS)
+        self.ttk.Label(parent, text="Fahrzeug").grid(
+            row=row, column=0, sticky="w", padx=4, pady=2
+        )
+        option = self.ttk.OptionMenu(
+            parent,
+            self.vehicle_var,
+            self.vehicle_var.get(),
+            "car",
+            "motorcycle",
+            "bike",
+        )
+        option.grid(row=row, column=1, sticky="ew", padx=4, pady=2)
+
+    def _collect_values(self, specs: Sequence[FieldSpec]) -> Dict[str, int | float | None]:
+        values: Dict[str, int | float | None] = {}
+        errors = []
+        for spec in specs:
+            try:
+                values[spec.key] = spec.parser(self.vars[spec.key].get(), spec.label)
+            except ValueError as exc:
+                errors.append(str(exc))
+        if errors:
+            raise ValueError("\n".join(errors))
+        return values
+
+    def _on_calculate(self) -> None:
+        try:
+            allowance_kwargs = self._collect_values(MEAL_FIELDS)
+            travel_kwargs = self._collect_values(TRAVEL_FIELDS)
+            travel_kwargs["vehicle"] = self.vehicle_var.get()
+
+            allowance = AllowanceInput(**allowance_kwargs)  # type: ignore[arg-type]
+            travel = TravelCostInput(**travel_kwargs)  # type: ignore[arg-type]
+
+            result = self.calculator.calculate(allowance, travel)
+        except ValueError as exc:
+            self.messagebox.showerror("Eingabefehler", str(exc))
+            return
+
+        self.total_var.set(f"{result.total_allowance:.2f} EUR")
+        self.meal_var.set(f"{result.meal_allowance:.2f} EUR")
+        self.travel_var.set(f"{result.travel_costs:.2f} EUR")
+        self._set_output_text("\n".join(format_breakdown(result)))
+
+    def _set_output_text(self, text: str) -> None:
+        self.output.configure(state="normal")
+        self.output.delete("1.0", "end")
+        self.output.insert("1.0", text)
+        self.output.configure(state="disabled")
+
+
+def launch_gui() -> None:
+    """Startet die Tkinter-Oberfläche."""
+
+    import tkinter as tk  # Imported lazily to avoid dependency during tests
+    from tkinter import messagebox, ttk
+    from tkinter import scrolledtext
+
+    root = tk.Tk()
+    CalculatorGUI(root, tk, ttk, messagebox, scrolledtext.ScrolledText)
+    root.mainloop()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual start
+    launch_gui()
+
+
+__all__ = [
+    "launch_gui",
+    "parse_int",
+    "parse_float",
+    "parse_optional_float",
+]


### PR DESCRIPTION
## Summary
- add a calculator core to estimate federal separation allowance and travel reimbursements
- provide a command line interface with JSON input support and documentation
- configure packaging metadata, tests, and gitignore for a clean workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd2042f444832ba91dd0f3a124b84a